### PR TITLE
Recursive

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,8 @@ fn recurse_songs(dir : &String) -> Result<Vec<String>, io::Error>{
             let memes = entry.unwrap().path();
             match try!(fs::metadata(memes.clone())).is_dir() {
                 false => toAppend.push(memes.to_str().unwrap().to_string()),
-                true => toAppend.append(&mut recurse_songs(&memes.to_str().unwrap().to_string()).unwrap()),
+                true => toAppend.append(&mut recurse_songs(&memes.to_str().unwrap()
+                                                           .to_string()).unwrap()),
             };
          }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,9 +237,10 @@ fn recurse_songs(dir : &String) -> Result<Vec<String>, io::Error>{
     let mut toAppend : Vec<String> = vec![];
     if try!(fs::metadata(&dir)).is_dir() {
         for entry in try!(fs::read_dir(dir)) {
-            match try!(fs::metadata(entry.unwrap().path())).is_dir() {
-                false => toAppend.push(second.unwrap().path().to_str().unwrap().to_string()),
-                true => {},
+            let memes = entry.unwrap().path();
+            match try!(fs::metadata(memes.clone())).is_dir() {
+                false => toAppend.push(memes.to_str().unwrap().to_string()),
+                true => toAppend.append(&mut recurse_songs(&memes.to_str().unwrap().to_string()).unwrap()),
             };
          }
     }


### PR DESCRIPTION
Added recursive functionality with tag -r,
Goes infinitely deep, because it is properly recursive.
Inserts the files inline and not at the end of queue.
Problems:
Lots of unwraps that will crash the program if rust encounters an error converting strings or if there is a file system error while looking for files.
