### PR TITLE
Ncurses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ argparse = "*"
 regex = "*"
 rustty = {version = "0.1.9", git = "https://github.com/cpjreynolds/rustty.git"}
 gstreamer = "*"
+ncurses = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,7 @@ fn loop_main (bus_receiver: gst::bus::Receiver,
                     }
                     UIResult::Exit => {
                         main_loop.quit();
+                        endwin();
                         return LoopResult::Clean;
                     }
                     UIResult::Error(a) => {

--- a/src/ncurse_ui.rs
+++ b/src/ncurse_ui.rs
@@ -1,0 +1,65 @@
+//  Copyright 2015 Nathanael Merrill
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use playlist;
+use ncurses::*;
+
+use std::sync::mpsc as cc;
+use std::error::Error;
+pub enum UIResult {
+    PlayPause,
+    Next,
+    Previous,
+    Exit,
+    Error(String),
+    NA,
+}
+
+pub struct UI {
+    x: i32,
+    y: i32,
+}
+//next step is to make the ui listing songs, and the step after that is to make the other window (rendered in main.rs)
+// that renders the timing progress bar based on the play loop
+impl UI {
+
+    pub fn new(tx :cc::Sender<UIResult>) -> UI {
+        initscr();
+        refresh();
+        let mut rx :i32 = 0;
+        let mut ry :i32 = 0;
+        while true {
+            getmaxyx(stdscr, &mut ry, &mut rx);
+            // printw(&*String::from(rx.to_string() + " , " + &ry.to_string()));
+            let mut ch = getch();
+            // printw(&*ch.to_string()); -- good for finding keycodes
+            match ch {
+                //n
+                110 => {tx.send(UIResult::Next);},
+                //p
+                112 => {tx.send(UIResult::Previous);},
+                //x
+                120 => {tx.send(UIResult::Exit);},
+                //spc
+                32 => {tx.send(UIResult::PlayPause);},
+                _ => {printw("no binding");}
+            }
+            refresh();
+        }
+        return UI {
+            x: 10,
+            y: 3,
+        };
+    }
+}

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -42,8 +42,8 @@ impl Playlist {
 
     // Tells playlist to go back to the song before.
     pub fn go_to_prev(&mut self) {
-        self.song_index -= 1;
         self.sender.send(self.song_index);
+        self.song_index -= 1;
     }
 
     // Returns the song that should currently be playing

--- a/src/playlist.rs
+++ b/src/playlist.rs
@@ -11,16 +11,18 @@
 //  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
-
+use std::sync::mpsc as cc;
 pub struct Playlist {
     pub songs: Vec<String>,
     pub song_index: i32,
+    sender: cc::Sender<i32>,
 }
 
 impl Playlist {
-    pub fn new(songs: Vec<String>) -> Playlist {
+    pub fn new(songs: Vec<String>, sender: cc::Sender<i32>) -> Playlist {
         Playlist{songs: songs,
-                 song_index: -1}
+                 song_index: -1,
+                 sender: sender}
     }
 
     // Returns the next song that should be played.
@@ -35,11 +37,13 @@ impl Playlist {
     // next one.
     pub fn go_to_next(&mut self) {
         self.song_index += 1;
+        self.sender.send(self.song_index);
     }
 
     // Tells playlist to go back to the song before.
     pub fn go_to_prev(&mut self) {
         self.song_index -= 1;
+        self.sender.send(self.song_index);
     }
 
     // Returns the song that should currently be playing


### PR DESCRIPTION
Started the beginning of the ncurses ui.
The reason it is separated in threads is because ncurses hangs for user input, 
So the only reason to keep the song playing in the background is to separate it into separate threads.
This pull request removes the ability to use the previous ui that uses the rustty lib.
This ui does not yet show the current song or the song progress, but that should be easy to do because ncurses has good support for separately updating panels.
